### PR TITLE
fix issue with incorrect log group physical id created for dynamodb streams

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,6 @@
 
 - Updated dependencies
 
-
 ### Fixed
 
 - Improved support for projects with enough CloudFormation resources to paginate calls

--- a/src/get-logical-id.js
+++ b/src/get-logical-id.js
@@ -8,6 +8,10 @@ module.exports = function getLogicalID (pathToCode) {
     // Websocket logical ids are prefixed with "Websocket"
     logicalID = 'Websocket' + logicalID
   }
+  else if (pathToCode.includes('/tables/')) {
+    // DynamoDB Stream logical ids are suffixed with "StreamLambda"
+    logicalID = logicalID + 'StreamLambda'
+  }
 
   return logicalID
 }

--- a/test/get-logical-id-tests.js
+++ b/test/get-logical-id-tests.js
@@ -11,6 +11,11 @@ test('should return logical id for websocket path', t => {
   t.equal(getLogicalID('./src/ws/default'), 'WebsocketDefault')
 })
 
+test('should return logical id for dynamodb stream path', t => {
+  t.plan(1)
+  t.equal(getLogicalID('./src/tables/default'), 'DefaultStreamLambda')
+})
+
 test('should replace references to 000 in path', t => {
   t.plan(1)
   t.equal(getLogicalID('./src/http/get-api-000version'), 'GetApiVersion')


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

This fixes https://github.com/architect/architect/issues/1004