### PR TITLE
Paginated cloudformation physical ID search

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
+    "aws-sdk-mock": "~5.1.0",
     "codecov": "^3.6.5",
     "cross-env": "~7.0.2",
     "eslint": "^7.0.0",

--- a/src/get-physical-id.js
+++ b/src/get-physical-id.js
@@ -7,19 +7,19 @@ let aws = require('aws-sdk')
  * @param {String} params.pathToCode - path to lambda code
  * @param {logicalID} params.logicalID - the logical id of the function
  */
-module.exports = function getPhysicalID({name, logicalID}, callback) {
-  let cloudformation = new aws.CloudFormation({region: process.env.AWS_REGION})
-  ;(function lookup(NextToken) {
+module.exports = function getPhysicalID ({ name, logicalID }, callback) {
+  let cloudformation = new aws.CloudFormation({ region: process.env.AWS_REGION })
+  ;(function lookup (NextToken) {
     cloudformation.listStackResources({
       StackName: name,
       NextToken
     },
-    function done(err, data) {
+    function done (err, data) {
       if (err) callback(err)
       else {
-        let find = i=> i.ResourceType === 'AWS::Lambda::Function'
+        let find = i => i.ResourceType === 'AWS::Lambda::Function'
         let functions = data.StackResourceSummaries.filter(find)
-        let found = functions.find(f=> f.LogicalResourceId === logicalID)
+        let found = functions.find(f => f.LogicalResourceId === logicalID)
         if (found) callback(null, found.PhysicalResourceId)
         else if (data.NextToken) lookup(data.NextToken)
         else callback()

--- a/test/get-physical-id-tests.js
+++ b/test/get-physical-id-tests.js
@@ -1,0 +1,45 @@
+let test = require('tape')
+const AWS = require('aws-sdk-mock')
+const sinon = require('sinon')
+let resourceStub = { StackResourceSummaries: [] }
+let fake = sinon.fake.yields(null, resourceStub)
+AWS.mock('CloudFormation', 'listStackResources', fake)
+let getPhysicalID = require('../src/get-physical-id')
+
+test('should return only return Lambda Function resource types', t => {
+  t.plan(1)
+  resourceStub.StackResourceSummaries = [
+    { ResourceType: 'AWS::Lambda::Function', LogicalResourceId: 'lambda', PhysicalResourceId: 'one' },
+    { ResourceType: 'AWS::Lambda::NotAFunction', LogicalResourceId: 'lambda', PhysicalResourceId: 'two' }
+  ]
+  getPhysicalID({ name: 'stackname', logicalID: 'lambda' }, function (err, id) {
+    if (err) t.fail('unexpected error in callback')
+    else t.equals(id, 'one')
+  })
+})
+
+test('should be able to paginate through multiple pages of results from CloudFormation', t => {
+  t.plan(1)
+  let pagefake = sinon.fake(function (params, callback) {
+    if (params.NextToken) {
+      resourceStub.StackResourceSummaries = [
+        { ResourceType: 'AWS::Lambda::Function', LogicalResourceId: 'gamma', PhysicalResourceId: 'four' }
+      ]
+    }
+    else {
+      resourceStub.StackResourceSummaries = [
+        { ResourceType: 'AWS::Lambda::Function', LogicalResourceId: 'alpha', PhysicalResourceId: 'one' },
+        { ResourceType: 'AWS::Lambda::Function', LogicalResourceId: 'beta', PhysicalResourceId: 'two' },
+        { ResourceType: 'AWS::Lambda::Function', LogicalResourceId: 'delta', PhysicalResourceId: 'three' }
+      ]
+      resourceStub.NextToken = '123'
+    }
+    callback(null, resourceStub)
+  })
+  AWS.remock('CloudFormation', 'listStackResources', pagefake)
+  getPhysicalID({ name: 'stackname', logicalID: 'gamma' }, function (err, id) {
+    if (err) t.fail('unexpected error in callback', err)
+    else t.equals(id, 'four')
+    AWS.restore()
+  })
+})


### PR DESCRIPTION
This implementation comes from @tobytailor and I added some tests for it.

I know CloudFormation recently upped its max limit of resources from 200 to 500. This change allows this module to handle multiple pages of stack resource results when searching for resources. Looks like CloudFormation.listStackResources has a 1MB max response size per page of results (that sounds familiar; I guess I know what db AWS uses to back their API!), so with the new 500 resource limit from CloudFormation, it's _more_ likely the paginated logic will be necessary.

@tobytailor did a few tweaks like this in other modules; I am going to take a look and send PRs elsewhere where needed, but want to Brian and Ryan's feedback first before I churn through the changes across all repos.

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

