### PR TITLE
add support for `@plugins`-authored Lambdas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       run: npm install
 
     - name: Test
-      run: npm run test:unit
+      run: npm test
       env:
         CI: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       run: npm install
 
     - name: Test
-      run: npm test
+      run: npm run test:unit
       env:
         CI: true
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [2.1.0] 2021-02-09
+
+### Added
+
+- Support for pulling logs from custom `@plugins`-defined Lambdas
+
+---
+
 ## [2.0.1] 2020-12-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@architect/logs",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Manage logging from Architect-provisioned cloud functions",
   "main": "index.js",
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "test:unit": "cross-env tape 'test/**/*-tests.js' | tap-spec",
-    "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
+    "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"
   },
@@ -42,6 +42,7 @@
     "codecov": "^3.8.1",
     "cross-env": "~7.0.3",
     "eslint": "^7.14.0",
+    "mock-require": "~3.0.3",
     "nyc": "^15.1.0",
     "sinon": "^9.2.1",
     "tap-spec": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/logs",
-  "version": "2.1.0",
+  "version": "2.1.0-RC.0",
   "description": "Manage logging from Architect-provisioned cloud functions",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run lint && npm run coverage",
-    "test:unit": "cross-env tape 'test/**/*-tests.js' | tap-spec",
+    "test:unit": "tape 'test/**/*-tests.js'",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/architect/logs#readme",
   "dependencies": {
-    "@architect/inventory": "~1.2.0",
+    "@architect/inventory": "~1.3.0-RC.0",
     "@architect/utils": "~2.0.2",
     "aws-sdk": "~2.712.0",
     "chalk": "~4.1.0",
@@ -42,6 +42,7 @@
     "codecov": "^3.8.1",
     "cross-env": "~7.0.3",
     "eslint": "^7.14.0",
+    "mock-fs": "~4.13.0",
     "mock-require": "~3.0.3",
     "nyc": "^15.1.0",
     "sinon": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run lint && npm run coverage",
-    "test:unit": "tape 'test/**/*-tests.js'",
+    "test:unit": "cross-env tape 'test/**/*-tests.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/logs",
-  "version": "2.1.0-RC.0",
+  "version": "2.1.0-RC.1",
   "description": "Manage logging from Architect-provisioned cloud functions",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/architect/logs#readme",
   "dependencies": {
-    "@architect/inventory": "~1.3.0-RC.0",
-    "@architect/utils": "~2.0.2",
+    "@architect/inventory": "~1.3.0-RC.1",
+    "@architect/utils": "~2.0.5-RC.0",
     "aws-sdk": "~2.712.0",
     "chalk": "~4.1.0",
     "run-parallel": "~1.2.0",

--- a/src/get-logical-id.js
+++ b/src/get-logical-id.js
@@ -21,22 +21,9 @@ module.exports = function getLogicalID (inventory, dir) {
   }
   Object.entries(lambdae).forEach(([ pragma, type ]) => {
     if (lambda) return
-    if (inv[pragma]) {
-      let ls = []
-      if (pragma == 'plugins') {
-        Object.values(inv[pragma]).forEach(pluginModule => {
-          if (pluginModule.pluginFunctions) {
-            ls = ls.concat(pluginModule.pluginFunctions(inv._project.arc, inventory))
-          }
-        })
-      }
-      else {
-        ls = inv[pragma]
-      }
-      ls.forEach(l => {
-        if (l.src.endsWith(pathToCode)) lambda = { ...l, type }
-      })
-    }
+    if (inv[pragma]) inv[pragma].forEach(l => {
+      if (l.src.endsWith(pathToCode)) lambda = { ...l, type }
+    })
   })
 
   if (lambda) {
@@ -47,16 +34,7 @@ module.exports = function getLogicalID (inventory, dir) {
       return `${id}HTTPLambda`
     }
     else {
-      let nameInput
-      if (name) {
-        // If lambda name explicitly provided, use that
-        nameInput = name
-      }
-      else {
-        // Otherwise, infer lambda name based on source path
-        nameInput = pathToCode.replace(/^src\/?\\?/, '')
-      }
-      let lambdaName = getLambdaName(nameInput)
+      let lambdaName = getLambdaName(name)
       let id = toLogicalID(lambdaName)
       return `${id}${type}Lambda`
     }

--- a/src/get-logical-id.js
+++ b/src/get-logical-id.js
@@ -47,7 +47,16 @@ module.exports = function getLogicalID (inventory, dir) {
       return `${id}HTTPLambda`
     }
     else {
-      let lambdaName = getLambdaName(name)
+      let nameInput
+      if (name) {
+        // If lambda name explicitly provided, use that
+        nameInput = name
+      }
+      else {
+        // Otherwise, infer lambda name based on source path
+        nameInput = pathToCode.replace(/^src\/?\\?/, '')
+      }
+      let lambdaName = getLambdaName(nameInput)
       let id = toLogicalID(lambdaName)
       return `${id}${type}Lambda`
     }

--- a/src/get-logical-id.js
+++ b/src/get-logical-id.js
@@ -13,6 +13,7 @@ module.exports = function getLogicalID (inventory, dir) {
   let lambdae = {
     events: 'Event',
     http: 'HTTP',
+    plugins: 'Plugin',
     queues: 'Queue',
     scheduled: 'Scheduled',
     streams: 'Stream',
@@ -20,9 +21,22 @@ module.exports = function getLogicalID (inventory, dir) {
   }
   Object.entries(lambdae).forEach(([ pragma, type ]) => {
     if (lambda) return
-    if (inv[pragma]) inv[pragma].forEach(l => {
-      if (l.src.endsWith(pathToCode)) lambda = { ...l, type }
-    })
+    if (inv[pragma]) {
+      let ls = []
+      if (pragma == 'plugins') {
+        Object.values(inv[pragma]).forEach(pluginModule => {
+          if (pluginModule.pluginFunctions) {
+            ls = ls.concat(pluginModule.pluginFunctions(inv._project.arc, inventory))
+          }
+        })
+      }
+      else {
+        ls = inv[pragma]
+      }
+      ls.forEach(l => {
+        if (l.src.endsWith(pathToCode)) lambda = { ...l, type }
+      })
+    }
   })
 
   if (lambda) {

--- a/test/get-logical-id-tests.js
+++ b/test/get-logical-id-tests.js
@@ -1,13 +1,22 @@
 let test = require('tape')
+let mockRequire = require('mock-require')
 let _inventory = require('@architect/inventory')
-let { sep } = require('path')
+let { sep, join } = require('path')
 let getLogicalID = require('../src/get-logical-id')
 let inventory
 
 test('Set up env', t => {
   t.plan(2)
   t.ok(getLogicalID, 'Logical ID module is present')
-  let rawArc = '@app\nappname\n@http\nget /\nget /api/:version\n@ws'
+  let rawArc = '@app\nappname\n@http\nget /\nget /api/:version\n@ws\n@plugins\nmyplugin\n@myplugin\ncustom-funk'
+  mockRequire(join(process.cwd(), 'src', 'plugins', 'myplugin.js'), {
+    pluginFunctions: function () {
+      return [ {
+        src: 'src/myplugin/custom-funk',
+        body: 'my body is my temple'
+      } ]
+    }
+  })
   _inventory({ rawArc }, (err, result) => {
     if (err) t.fail(err)
     else {
@@ -37,4 +46,10 @@ test('should blow up on unknown path', t => {
   t.throws(() => {
     getLogicalID(inventory, `.${sep}src${sep}http${sep}idk`)
   }, 'Threw on unknown path')
+})
+
+// TODO: uncomment this once inventory dependency is bumped
+test.skip('should include PluginLambda for plugin-registered Lambdas', t => {
+  t.plan(1)
+  t.equal(getLogicalID(inventory, `.${sep}src${sep}myplugin${sep}custom-funk`), 'CustomFunkPluginLambda')
 })

--- a/test/get-logical-id-tests.js
+++ b/test/get-logical-id-tests.js
@@ -1,4 +1,5 @@
 let test = require('tape')
+let mockFs = require('mock-fs')
 let mockRequire = require('mock-require')
 let _inventory = require('@architect/inventory')
 let { sep, join } = require('path')
@@ -9,14 +10,20 @@ test('Set up env', t => {
   t.plan(2)
   t.ok(getLogicalID, 'Logical ID module is present')
   let rawArc = '@app\nappname\n@http\nget /\nget /api/:version\n@ws\n@plugins\nmyplugin\n@myplugin\ncustom-funk'
-  mockRequire(join(process.cwd(), 'src', 'plugins', 'myplugin.js'), {
+  let fakePluginPath = join(process.cwd(), 'src', 'plugins', 'myplugin.js')
+  // because mock-fs forces you to use / even on windows :| :| :|
+  let unixFakePluginPath = fakePluginPath.replace(/\\/g, '/')
+  let mocks = {}
+  mocks[unixFakePluginPath] = 'fake file contents'
+  mockRequire(fakePluginPath, {
     pluginFunctions: function () {
       return [ {
-        src: 'src/myplugin/custom-funk',
+        src: join(process.cwd(), 'src', 'myplugin', 'custom-funk'),
         body: 'my body is my temple'
       } ]
     }
   })
+  mockFs(mocks)
   _inventory({ rawArc }, (err, result) => {
     if (err) t.fail(err)
     else {
@@ -26,30 +33,36 @@ test('Set up env', t => {
   })
 })
 
-test('should return logical id for path', t => {
+test('get-logical-id should return logical id for path', t => {
   t.plan(1)
   t.equal(getLogicalID(inventory, `.${sep}src${sep}http${sep}get-index`), 'GetIndexHTTPLambda')
 })
 
-test('should return logical id for websocket path', t => {
+test('get-logical-id should return logical id for websocket path', t => {
   t.plan(1)
   t.equal(getLogicalID(inventory, `.${sep}src${sep}ws${sep}default`), 'DefaultWSLambda')
 })
 
-test('should replace references to 000 in path', t => {
+test('get-logical-id should replace references to 000 in path', t => {
   t.plan(1)
   t.equal(getLogicalID(inventory, `.${sep}src${sep}http${sep}get-api-000version`), 'GetApiVersionHTTPLambda')
 })
 
-test('should blow up on unknown path', t => {
+test('get-logical-id should blow up on unknown path', t => {
   t.plan(1)
   t.throws(() => {
     getLogicalID(inventory, `.${sep}src${sep}http${sep}idk`)
   }, 'Threw on unknown path')
 })
 
-// TODO: uncomment this once inventory dependency is bumped
-test.skip('should include PluginLambda for plugin-registered Lambdas', t => {
+test('get-logical-id should include name plugin-registered Lambdas based on the path and contain a PluginLambda suffix', t => {
   t.plan(1)
-  t.equal(getLogicalID(inventory, `.${sep}src${sep}myplugin${sep}custom-funk`), 'CustomFunkPluginLambda')
+  t.equal(getLogicalID(inventory, `.${sep}src${sep}myplugin${sep}custom-funk`), 'MypluginCustomFunkPluginLambda')
+})
+
+test('get-logical-id teardown env', t => {
+  t.plan(1)
+  mockRequire.stopAll()
+  mockFs.restore()
+  t.pass('mocks torn down')
 })

--- a/test/index-tests.js
+++ b/test/index-tests.js
@@ -40,8 +40,8 @@ test('`logs` invokes `read` by default and passes the path to it', t => {
     else {
       t.equals(fakeTwo.lastCall.args[0].pathToCode, path, 'pathToCode passed to read method')
     }
+    sinon.restore()
   })
-  sinon.restore()
 })
 
 test('`logs` invokes `destroy` when specified via args and passes the path to it', t => {
@@ -56,6 +56,6 @@ test('`logs` invokes `destroy` when specified via args and passes the path to it
     else {
       t.equals(fakeTwo.lastCall.args[0].pathToCode, path, 'pathToCode passed to destroy method')
     }
+    sinon.restore()
   })
-  sinon.restore()
 })


### PR DESCRIPTION
Plugins can define new lambdas. Plugin authors should use a helper method provided in `package` called `createLambdaJSON` (see architect/package#101) to augment their CFN JSON. This method returns both a lambda CFN definition JSON _as well as_ a name for use by the author. This architect-provided name is integral for `logs` to be able to pull CloudWatch logs for plugin-defined Lambdas.

Still TODO:

- [x] wait for plugins support in inventory to land and be published (architect/inventory#15) and un-skip the unit test in this PR

Setting this as a draft PR until all the other PRs for the other core arc packages are ready as well.

Relevant content:

- The Plugin Authoring docs PR is here: architect/arc.codes#324
- The original RFC is here: architect/architect#1062