### PR TITLE
re-enable tap-spec with the mock-fs branch fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run lint && npm run coverage",
-    "test:unit": "tape 'test/**/*-tests.js'",
+    "test:unit": "cross-env tape 'test/**/*-tests.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"
@@ -42,7 +42,7 @@
     "codecov": "^3.8.1",
     "cross-env": "~7.0.3",
     "eslint": "^7.14.0",
-    "mock-fs": "~4.13.0",
+    "mock-fs": "github:tschaub/mock-fs#std",
     "mock-require": "~3.0.3",
     "nyc": "^15.1.0",
     "sinon": "^9.2.1",


### PR DESCRIPTION
This relates to the weird bug around using tape and mock-fs (see https://github.com/tschaub/mock-fs/issues/201)

Let's see if windows tests pass!