### PR TITLE
If no Lambda is specified, default to `@http` root handler (if possible)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [4.1.0] 2023-11-02
+
+### Added
+
+- If no Lambda is specified, default to `@http` root handler (if possible)
+- Added ability to specify an absolute file path for logs
+
+---
+
 ## [4.0.10] 2023-08-14
 
 ### Changed

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ let { join } = require('path')
 let pretty = require('./pretty-print')
 let destroyLogs = require('./destroy-logs')
 let readLogs = require('./read-logs')
-
+let cwd = process.cwd()
 
 /**
  * arc logs src/http/get-index ................... gets staging logs
@@ -31,9 +31,16 @@ module.exports = function logs (params = {}, callback) {
   }
   let { inventory, pathToCode, verbose, destroy, production } = params
 
-  // flags
   let ts = Date.now()
-  let exists = (typeof pathToCode !== 'undefined' && fs.existsSync(join(process.cwd(), pathToCode)))
+  let rootHandler = inventory.inv._project.rootHandler
+  if (!pathToCode && rootHandler) {
+    let handler = inventory.inv.http.find(({ name }) => name === rootHandler)
+    pathToCode = handler.src
+    let update = utils.updater('Logs')
+    update.status(`No Lambda specified; using root @http handler (${rootHandler})`)
+  }
+  let dir = pathToCode.startsWith(cwd) ? pathToCode : join(cwd, pathToCode)
+  let exists = (typeof pathToCode !== 'undefined' && fs.existsSync(dir))
 
   // config
   let appname = inventory.inv.app


### PR DESCRIPTION
Added ability to specify an absolute file path for logs

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
